### PR TITLE
Remove the request-response hashmaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "mongoproxy"
-version = "0.5.14"
+version = "0.5.15"
 dependencies = [
  "async-bson",
  "bson",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongoproxy"
-version = "0.5.14"
+version = "0.5.15"
 authors = ["mpihlak <martin.pihlak@starship.co>"]
 edition = "2018"
 


### PR DESCRIPTION
Since we're now serializing the requests and responses there should be no way for them to arrive out of order and we can do away with all the delayed response to request mapping the hashmaps and associated counters.
