### PR TITLE
Downgrade regex to avoid compat issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +637,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
  "prometheus",
+ "regex",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",
@@ -884,6 +894,8 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax 0.7.1",
 ]
 

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -25,3 +25,4 @@ opentelemetry = { version="0.12", features = ["tokio-support"] }
 opentelemetry-jaeger = { version="0.11", features = ["tokio"] }
 mongo-protocol = { path="../mongo-protocol" }
 async-bson = { path="../async-bson" }
+regex = "1.4.2"


### PR DESCRIPTION
This should fix the following panic:
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Syntax(
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
regex parse error:
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1: (?x)
 2:                 ^(?P<global_level>(?i:trace|debug|info|warn|error|off|[0-5]))$ |
                                          ^
 3:                  #                 ^^^.
 4:                  #                     `note: we match log level names case-insensitively
 5:                 ^
 6:                 (?: # target name or span name
 7:                     (?P<target>[\w:-]+)|(?P<span>\[[^\]]*\])
 8:                 ){1,2}
 9:                 (?: # level or nothing
10:                     =(?P<level>(?i:trace|debug|info|warn|error|off|[0-5]))?
11:                      #          ^^^.
12:                      #              `note: we match log level names case-insensitively
13:                 )?
14:                 $
15:
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error: Unicode-aware case insensitivity matching is not available (make sure the unicode-case feature is enabled)
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
