### PR TITLE
fix: remove building when having a tag and use arm64 instead of arm/v8

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -2,8 +2,6 @@ name: Build
 
 on:
   push:
-    tags:
-      - v*
 
 jobs:
   build:
@@ -31,7 +29,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64,linux/arm/v8
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This will fix the errors. The problem was that QEMU didn't accept 32-bit on 64-bit processors.

https://gitlab.com/qemu-project/qemu/-/issues/263 