### PR TITLE
feat: use cross compilation for building the docker image.

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -2,6 +2,11 @@ name: Build
 
 on:
   push:
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -2,8 +2,6 @@ name: Build
 
 on:
   push:
-    tags:
-      - v*
 
 jobs:
   build:
@@ -31,7 +29,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/amd64,linux/arm/v8
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN xx-cargo build --release --target-dir ./
 
 FROM debian:buster-slim
 
-COPY --from=xx / /
 RUN apt-get update && apt-get install -y iptables
 RUN update-alternatives --set iptables /usr/sbin/iptables-legacy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM rust:1.61-buster as builder
+# Needed for rust cross compilation helper scripts.
+# https://github.com/tonistiigi/xx#rust
+FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
+
+FROM --platform=$BUILDPLATFORM rust:1.61-buster as builder
+
+COPY --from=xx / /
 
 WORKDIR /build/mongoproxy
 
@@ -7,11 +13,17 @@ COPY proxy/ ./proxy
 COPY mongo-protocol/ ./mongo-protocol
 COPY async-bson/ ./async-bson
 
-RUN cargo build --release
+RUN apt-get update && apt-get install -y clang lld
+
 RUN cargo test --release
+ARG TARGETPLATFORM
+
+RUN xx-apt-get install -y xx-c-essentials
+RUN xx-cargo build --release --target-dir ./
 
 FROM debian:buster-slim
 
+COPY --from=xx / /
 RUN apt-get update && apt-get install -y iptables
 RUN update-alternatives --set iptables /usr/sbin/iptables-legacy
 
@@ -19,7 +31,7 @@ RUN adduser --uid 9999 --disabled-password --gecos '' mongoproxy
 USER mongoproxy
 
 WORKDIR /mongoproxy
-COPY --from=builder /build/mongoproxy/target/release/mongoproxy ./
+COPY --from=builder /build/mongoproxy/*/release/mongoproxy ./
 COPY iptables-init.sh .
 
 ENV MALLOC_ARENA_MAX 2


### PR DESCRIPTION
Using QEMU for emulation makes the github action gets killed because it's probably running out of memory. This PR should be built without emulation.