### PR TITLE
Fix replicaset parsing for newer versions of MongoDB

### DIFF
--- a/proxy/src/tracker.rs
+++ b/proxy/src/tracker.rs
@@ -692,7 +692,7 @@ impl MongoStatsTracker{
 
     fn try_parsing_replicaset(&mut self, doc: &Document) {
         if let Some(op) = doc.get_str("op") {
-            if op == "hosts" {
+            if (op == "hosts") || (op == "helloOk") {
                 if let Some(replicaset) = doc.get_str("replicaset") {
                     self.replicaset = replicaset.to_owned();
                 }


### PR DESCRIPTION
Fix replica set parsing for MongoDB versions 5.0+, which have `helloOk` "operation" instead of `hosts` as in previous versions. Currently replicaset is not parsed correctly and label is empty. After the change `mongoproxy` is confirmed to be working as expected in our test environment, `replicaset` label is populated.