### PR TITLE
Fix replicaset parsing for older clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "mongoproxy"
-version = "0.5.29"
+version = "0.5.30"
 dependencies = [
  "async-bson",
  "bson",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongoproxy"
-version = "0.5.29"
+version = "0.5.30"
 authors = ["mpihlak <martin.pihlak@starship.co>"]
 edition = "2018"
 

--- a/proxy/src/tracker.rs
+++ b/proxy/src/tracker.rs
@@ -692,7 +692,7 @@ impl MongoStatsTracker{
 
     fn try_parsing_replicaset(&mut self, doc: &Document) {
         if let Some(op) = doc.get_str("op") {
-            if (op == "hosts") || (op == "helloOk") {
+            if (op == "hosts") || (op == "helloOk") || (op == "topologyVersion") {
                 if let Some(replicaset) = doc.get_str("replicaset") {
                     self.replicaset = replicaset.to_owned();
                 }


### PR DESCRIPTION
Older drivers do not support `helloOk` and have `topologyVersion` instead of `hosts` in MongoDB messages starting from 4.4.