### PR TITLE
Ensure ordering in the tracker channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "mongoproxy"
-version = "0.5.32"
+version = "0.5.34"
 dependencies = [
  "async-bson",
  "bson",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongoproxy"
-version = "0.5.32"
+version = "0.5.34"
 authors = ["mpihlak <martin.pihlak@starship.co>"]
 edition = "2018"
 

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -331,15 +331,19 @@ async fn proxy_loop(
                     // TODO: Increase a counter
                     break;
                 }
+                // TODO: Remove this
+                debug!("Have message, will send to tracker");
                 if let Err(e) = tracker.send((is_client, hdr, msg)).await {
-                    warn!("error sending message to server tracker: {e}");
+                    warn!("error sending message to tracker: {e}");
                     // TODO: Increase a counter
                     break;
                 }
+                // TODO: Remove this
+                debug!("Sent to tracker");
             },
             Err(ProxyError::EOF) => break,
             Err(e) => {
-                warn!("error processing server message: {e}");
+                warn!("error getting Mongo message from reader: {e}");
                 break;
             },
         }

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -326,7 +326,7 @@ async fn proxy_loop(
     loop {
         match proxy.proxy_mongo_message(read_source, &mut read_from).await {
             Ok((hdr, msg, buf)) => {
-                if let Err(e) = write_to.write_all(&buf).await {
+                if let Err(e) = write_to.write_all(buf).await {
                     warn!("error writing bytes to the other end: {e}");
                     // TODO: Increase a counter
                     break;


### PR DESCRIPTION
Write the bytes to the socket only after the message has been sent to
the tracker. Otherwise it is possible that the client and server
messages reach the tracker out of order and cause some messages not to
be counted.