### PR TITLE
feat: add release binary uploads

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - v[0-9]+.*
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-assets:
+    needs: create-release
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          # - target: aarch64-apple-darwin
+          #   os: macos-latest
+          # - target: x86_64-apple-darwin
+          #   os: macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cross-compilation tools
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+        if: startsWith(matrix.os, 'ubuntu')
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: mongoproxy
+          target: ${{ matrix.target }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Build for Linux x86_64 and aarch64 targets and upload binaries to release.

This is using the [upload-rust-binary-action](https://github.com/marketplace/actions/build-and-upload-rust-binary-to-github-releases) with [setup-cross-toolchain-action](https://github.com/taiki-e/setup-cross-toolchain-action).

---

To build aarch64 similarly locally on Ubuntu 24.04, add tool-chain with `rustup target add aarch64-unknown-linux-gnu`, install `gcc-aarch64-linux-gnu` package and add to `~/.cargo/config.toml`:

```toml
[target.aarch64-unknown-linux-gnu]
linker = "aarch64-linux-gnu-gcc"
```

Then build for aarch64 platform with `cargo build --release --target=aarch64-unknown-linux-gnu`.