### PR TITLE
Rename the 'app' label on metrics to 'appname'

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Per-request histograms:
 * `mongoproxy_client_request_bytes_total` - Request size distribution.
 * `mongoproxy_server_response_bytes_total` - Response size distribution.
 
-All per-request metrics are labeled with `client` (IP address), `app` (appName from connection metadata), `op`, `collection`, `db`, `server` and `replicaset`. 
+All per-request metrics are labeled with `client` (IP address), `appname` (appName from connection metadata), `op`, `collection`, `db`, `server` and `replicaset`. 
 
 Connection counters
 * `mongoproxy_client_connections_established_total`

--- a/proxy/src/tracker.rs
+++ b/proxy/src/tracker.rs
@@ -17,14 +17,14 @@ use opentelemetry::KeyValue;
 use async_bson::Document;
 
 // Common labels for all op metrics
-const OP_LABELS: &[&str] = &["client", "app", "op", "collection", "db", "replicaset", "server", "username"];
+const OP_LABELS: &[&str] = &["client", "appname", "op", "collection", "db", "replicaset", "server", "username"];
 
 lazy_static! {
     static ref APP_CONNECTION_COUNT_TOTAL: CounterVec =
         register_counter_vec!(
             "mongoproxy_app_connections_established_total",
             "Total number of client connections established",
-            &["app"]).unwrap();
+            &["appname"]).unwrap();
 
     // This is a separate counter because the app and user label values arrive at different
     // times (if at all). So there is no good way to determine if we have both.
@@ -38,7 +38,7 @@ lazy_static! {
         register_counter_vec!(
             "mongoproxy_app_disconnections_total",
             "Total number of client disconnections",
-            &["app", "username"]).unwrap();
+            &["appname", "username"]).unwrap();
 
     static ref UNSUPPORTED_OPNAME_COUNTER: CounterVec =
         register_counter_vec!(


### PR DESCRIPTION
This corresponds better to the name used in connstring (`appName`). Also it will not conflict with common kubernetes labels that often get assigned to `app`.

Also see:
https://www.mongodb.com/docs/manual/reference/connection-string-options/#miscellaneous-configuration https://kubernetes.io/docs/reference/labels-annotations-taints/#app-kubernetes-io-name